### PR TITLE
Potential fix for code scanning alert no. 2: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/src/routes/api/shorten.ts
+++ b/src/routes/api/shorten.ts
@@ -221,10 +221,13 @@ export const route: Route = {
 
 async function generateSlug(length = 6): Promise<string> {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    const bytes = randomBytes(length);
     let result = '';
-    for (let i = 0; i < length; i++) {
-        result += chars[bytes[i]! % chars.length];
+    while (result.length < length) {
+        const byte = randomBytes(1)[0];
+        if (byte >= 256 - (256 % chars.length)) {
+            continue;
+        }
+        result += chars[byte % chars.length];
     }
     const existingSlug = await Link.findOne({ slugs: result });
     if (existingSlug) return generateSlug(length);
@@ -234,10 +237,13 @@ async function generateSlug(length = 6): Promise<string> {
 
 function generatePassword(length = 12): string {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    const bytes = randomBytes(length);
     let password = '';
-    for (let i = 0; i < length; i++) {
-        password += chars[bytes[i]! % chars.length];
+    while (password.length < length) {
+        const byte = randomBytes(1)[0];
+        if (byte >= 256 - (256 % chars.length)) {
+            continue;
+        }
+        password += chars[byte % chars.length];
     }
     return password;
 }

--- a/src/routes/api/shorten.ts
+++ b/src/routes/api/shorten.ts
@@ -224,10 +224,10 @@ async function generateSlug(length = 6): Promise<string> {
     let result = '';
     while (result.length < length) {
         const byte = randomBytes(1)[0];
-        if (byte >= 256 - (256 % chars.length)) {
+        if (byte! >= 256 - (256 % chars.length)) {
             continue;
         }
-        result += chars[byte % chars.length];
+        result += chars[byte! % chars.length];
     }
     const existingSlug = await Link.findOne({ slugs: result });
     if (existingSlug) return generateSlug(length);
@@ -240,10 +240,10 @@ function generatePassword(length = 12): string {
     let password = '';
     while (password.length < length) {
         const byte = randomBytes(1)[0];
-        if (byte >= 256 - (256 % chars.length)) {
+        if (byte! >= 256 - (256 % chars.length)) {
             continue;
         }
-        password += chars[byte % chars.length];
+        password += chars[byte! % chars.length];
     }
     return password;
 }

--- a/src/routes/api/shorten.ts
+++ b/src/routes/api/shorten.ts
@@ -224,14 +224,11 @@ async function generateSlug(length = 6): Promise<string> {
     let result = '';
     while (result.length < length) {
         const byte = randomBytes(1)[0];
-        if (byte! >= 256 - (256 % chars.length)) {
-            continue;
-        }
+        if (byte! >= 256 - (256 % chars.length)) continue;
         result += chars[byte! % chars.length];
     }
     const existingSlug = await Link.findOne({ slugs: result });
     if (existingSlug) return generateSlug(length);
-
     return result;
 }
 
@@ -240,9 +237,7 @@ function generatePassword(length = 12): string {
     let password = '';
     while (password.length < length) {
         const byte = randomBytes(1)[0];
-        if (byte! >= 256 - (256 % chars.length)) {
-            continue;
-        }
+        if (byte! >= 256 - (256 % chars.length)) continue;
         password += chars[byte! % chars.length];
     }
     return password;


### PR DESCRIPTION
Potential fix for [https://github.com/thaddeuskkr/nova/security/code-scanning/2](https://github.com/thaddeuskkr/nova/security/code-scanning/2)

To fix the problem, we need to avoid using the modulo operator on cryptographically secure random numbers. Instead, we can use a method that ensures uniform distribution of the random values. One way to achieve this is by discarding any random bytes that would introduce bias, similar to the provided example in the background information.

We will modify the `generateSlug` and `generatePassword` functions to discard any random bytes that are greater than or equal to the largest multiple of `chars.length` that is less than 256. This ensures that the modulo operation is performed on a uniformly random number.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
